### PR TITLE
DOC: Adds ma.correlate examples

### DIFF
--- a/numpy/ma/core.py
+++ b/numpy/ma/core.py
@@ -8147,11 +8147,11 @@ def correlate(a, v, mode='valid', propagate_mask=True):
 
     Examples
     --------
-    Basic correlation:
+    Basic correlation adds a mask:
 
-    >>> a = np.ma.array([1, 2, 3])
-    >>> v = np.ma.array([0, 1, 0])
-    >>> np.ma.correlate(a, v, mode='valid')
+    >>> a = np.array([1, 2, 3])
+    >>> v = np.array([0, 1, 0])
+    >>> np.ma.correlate(a, v)
     masked_array(data=[2],
                  mask=[False],
            fill_value=999999)
@@ -8160,18 +8160,18 @@ def correlate(a, v, mode='valid', propagate_mask=True):
 
     >>> a = np.ma.array([1, 2, 3], mask=[False, True, False])
     >>> v = np.ma.array([0, 1, 0])
-    >>> np.ma.correlate(a, v, mode='valid', propagate_mask=True)
+    >>> np.ma.correlate(a, v)
     masked_array(data=[--],
                  mask=[ True],
            fill_value=999999,
                 dtype=int64)
 
-    Correlation with different modes:
+    Correlation with different modes and mixed elements:
 
-    >>> a = np.ma.array([1, 2, 3])
-    >>> v = np.ma.array([0, 1, 0])
-    >>> np.ma.correlate(a, v, mode='full')
-    masked_array(data=[0, 1, 2, 3, 0],
+    >>> a = np.array([1, 2, 3])
+    >>> v = np.ma.array([0, 1, 2], mask=[False, True, False])
+    >>> np.ma.correlate(a, v, mode='full', propagate_mask=False)
+    masked_array(data=[2, 4, 6, 0, 0],
                  mask=[False, False, False, False, False],
            fill_value=999999)
 


### PR DESCRIPTION
I adapted the AI generated examples.
I removed the default parameters.
First example shows how ma.correlate adds a mask to regular arrays. Second example shows basic usage with defaults.
Third example introduces mixed arrays and other options.

[skip actions] [skip azp] [skip cirrus]

I think these changes provide a higher chance of the examples being not too trivial.  Anytime AI uses the default parameters, check that and remove them. Most of the changes I made were just to showcase more options and mixing masked/non masked arrays. 